### PR TITLE
Issue#9

### DIFF
--- a/conf-template/taurus/graphdb/component-test.yml
+++ b/conf-template/taurus/graphdb/component-test.yml
@@ -1,0 +1,17 @@
+---
+  execution:
+  - concurrency: 5
+    hold-for: 30s
+    ramp-up: 10s
+    scenario: simple
+  
+  scenarios:
+    simple:
+      data-sources:
+      - graph-add-persons.csv
+      requests:
+      - label: add
+        method: POST
+        url: http://tinkerpop-graphdb-schema-loader:${GRAPHDB_PERSONA_SCHEMA_LOADER_PORT}
+        body: |
+          {"gremlin": "g.addV('P.identity').property('P.identity.id','${PERSON_ID}').property('P.identity.core.fullName', '${PERSON_NAME}')"}

--- a/conf-template/taurus/graphdb/graph-add-persons.csv
+++ b/conf-template/taurus/graphdb/graph-add-persons.csv
@@ -1,0 +1,11 @@
+PERSON_ID,PERSON_NAME
+1,foo
+2,bar
+3,baz
+4,car
+5,daz
+6,fab
+7,zad
+8,zab
+9,wac
+10,bac

--- a/k8s-perf-test/taurus-job.yaml
+++ b/k8s-perf-test/taurus-job.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: taurus-job
+spec:
+  backoffLimit: 5
+  activeDeadlineSeconds: 100
+  template:
+    spec:
+      containers:
+      - name: taurus-job
+        image: UKHomeOffice/taurus
+        command: 
+          - bzt -l bzt.log /bzt-tests-config/*.yml
+
+        volumeMounts:
+          - name: bzt
+            mountPath: /bzt
+
+          - name: bzt-tests-config
+            mountPath: /bzt-tests-config
+
+      restartPolicy: Never
+
+      volumes:
+      - name: bzt
+        hostPath:
+          path: /bzt 
+          type: Directory
+
+      - name: bzt-tests-config
+        configMap:
+          name: bzt-tests-config
+
+

--- a/vars/common.cfg
+++ b/vars/common.cfg
@@ -1,5 +1,5 @@
 GRAPHDB_COMMON_NAMESPACE=janusgraph$(echo ${KUBE_NAMESPACE} | sed -e 's/-//g')
-GRAPHDB_PERSONA_SCHEMA_LOADER_K8S_IMAGE=$(cat ${BASE_DIR}/environments/${KUBE_NAMESPACE}/cdp-deployment-templates/manifest/docker-tinkerpop-graphdb)
+GRAPHDB_PERSONA_SCHEMA_LOADER_K8S_IMAGE=$(cat ${ENV_OPERATION_BASE_DIR}/cdp-deployment-templates/manifest/docker-tinkerpop-graphdb)
 
 
 ELASTICSEARCH_K8S_IMAGE=quay.io/ukhomeofficedigital/docker-elasticsearch-base:6.7.0


### PR DESCRIPTION
The current dynamoDB backend can incur huge costs to the environment during performance tests. This change enables us to reduce that by having an embedded backend in the graph. The two main options are to use an in-memory graph, which does not work well with indices, or an embedded cassandra instance, which does; therefore we will pick the latter.

