### PR TITLE
JWT auth for graphdb service

### DIFF
--- a/conf-template/envoy/envoy.yaml
+++ b/conf-template/envoy/envoy.yaml
@@ -1,0 +1,74 @@
+admin:
+  access_log_path: "/dev/stdout"
+  address:
+    socket_address: { address: 0.0.0.0, port_value: ${ENVOY_ADMIN_PORT} }
+
+cluster_manager:
+  outlier_detection:
+    event_log_path: "/dev/stdout"
+
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address: { address: 0.0.0.0, port_value: ${ENVOY_PORT} }
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          access_log:
+          - name: envoy.file_access_log
+            config:
+              path: "/dev/stdout"
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: "/"
+                route: { cluster: service }
+          http_filters:
+          - name: envoy.filters.http.jwt_authn
+            config:
+              providers:
+                jwt_provider:
+                  issuer: "https://${KEYCLOAK_HOST}/auth/realms/${KEYCLOAK_REALM}"
+                  remote_jwks:
+                    http_uri:
+                      uri: "https://${KEYCLOAK_HOST}/auth/realms/${KEYCLOAK_REALM}/protocol/openid-connect/certs"
+                      cluster: auth
+                    cache_duration:
+                      seconds: 300
+                  forward: true
+              rules:
+              - match:
+                  prefix: /
+                requires:
+                  provider_and_audiences:
+                    provider_name: jwt_provider
+                    audiences:
+                      ${KEYCLOAK_CLIENT}
+          - name: envoy.router
+  clusters:
+  - name: service
+    common_lb_config:
+      healthy_panic_threshold:
+        value: 0.0
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    dns_lookup_family: V4_ONLY
+    lb_policy: ROUND_ROBIN
+    hosts: [{ socket_address: { address: localhost, port_value: ${GRAPHDB_PERSONA_SCHEMA_LOADER_PORT} }}]
+  - name: auth
+    common_lb_config:
+      healthy_panic_threshold:
+        value: 0.0
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    dns_lookup_family: V4_ONLY
+    lb_policy: ROUND_ROBIN
+    hosts: [{ socket_address: { address: ${KEYCLOAK_HOST}, port_value: 443 }}]
+    tls_context: { sni: ${KEYCLOAK_HOST} }

--- a/k8s-template/tinkerpop-graphdb-schema-loader.yaml
+++ b/k8s-template/tinkerpop-graphdb-schema-loader.yaml
@@ -22,6 +22,36 @@ spec:
 
     spec:
       containers:
+        - name: envoy
+          image: "docker-hub.digital.homeoffice.gov.uk/envoyproxy/envoy:v${ENVOY_VERSION}"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - mountPath: /etc/envoy
+              name: envoy-config
+              readOnly: true
+          resources:
+            requests:
+              cpu: 500m
+              memory: 200Mi
+            limits:
+              cpu: 500m
+              memory: 200Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: ${ENVOY_ADMIN_PORT}
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /
+              port: ${ENVOY_ADMIN_PORT}
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          command: ["/usr/local/bin/envoy"]
+          args: ["-c", "/etc/envoy/envoy.yaml"]
         - name: tinkerpop-graphdb-schema-loader
           image: ${GRAPHDB_PERSONA_SCHEMA_LOADER_K8S_IMAGE}
           imagePullPolicy: Always
@@ -75,6 +105,9 @@ spec:
           command: ["/opt/graphdb/bin/run-graph.sh", "/opt/graphdb/conf/gremlin-server-embedded.yml" ]
       restartPolicy: Always
       volumes:
+        - name: envoy-config
+          configMap:
+            name: envoy
         - name: config
           configMap:
             name: tinkerpop-graphdb-schema-loader
@@ -93,8 +126,8 @@ spec:
   ports:
     - name: http
       protocol: TCP
-      targetPort: ${GRAPHDB_PERSONA_SCHEMA_LOADER_PORT}
-      port: ${GRAPHDB_PERSONA_SCHEMA_LOADER_PORT}
+      targetPort: ${ENVOY_PORT}
+      port: 8182
   selector:
     name: tinkerpop-graphdb-schema-loader
   sessionAffinity: None
@@ -115,6 +148,4 @@ spec:
               name: ${KUBE_NAMESPACE}
       ports:
         - protocol: TCP
-          port: ${GRAPHDB_PERSONA_SCHEMA_LOADER_PORT}
-
-  
+          port: ${ENVOY_PORT}

--- a/vars/common.cfg
+++ b/vars/common.cfg
@@ -23,6 +23,14 @@ GRAPHDB_PERSONA_SCHEMA_LOADER_PORT=8182
 GRAPHDB_PERSONA_SCHEMA_LOADER_THREAD_POOL_WORKER=3
 
 
+ENVOY_PORT="10000"
+ENVOY_ADMIN_PORT="9901"
+ENVOY_VERSION="1.10.0"
+
+KEYCLOAK_HOST="sso.digital.homeoffice.gov.uk"
+KEYCLOAK_REALM="cdp"
+KEYCLOAK_CLIENT="test"
+
 # THESE vars are required to make the test case var substitution work (the issue is that envsubst blindingly substitutes ${xxx}, and 
 # Blazemeter Taurus uses ${xxx} as placeholders in their queries for variable substitution with a CSV file):
 


### PR DESCRIPTION
Adds an envoy-based reverse proxy to the graphdb pods in order to
perform JWT-based auth.

In order to access the service a toke will need to be obtained using
the `test` client in CDP's Keycloak realm. e.g.

```bash
curl -fsS -d 'client_id=test&client_secret=CLIENT_SECRET&grant_type=client_credentials' 'https://sso.digital.homeoffice.gov.uk/auth/realms/cdp/protocol/openid-connect/token' | jq -r '.access_token'
```

This token will need to be suppied on the authorization header on the
request:

```
Authorization: Bearer TOKEN
```

Addresses: CDMP-2210